### PR TITLE
fix optimization for getMatch when levenshtein is enabled

### DIFF
--- a/src/Data/FuzzySet/Internal.hs
+++ b/src/Data/FuzzySet/Internal.hs
@@ -23,10 +23,11 @@ getMatch GetContext{..} size = match <$$> filtered
     match α = set ^._exactSet.ix α
     filtered = filter ((<) minScore ∘ fst) sorted
     μ p = p & _1.~ distance (p ^._2) key
-    sorted = sortBy (flip compare `on` fst) $
+    sortByFst = sortBy (flip compare `on` fst)
+    sorted = sortByFst $
         let rs = results GetContext{..} size
          in if set ^._useLevenshtein
-                then take 50 (μ <$> rs)
+                then (fmap μ ∘ take 50 ∘ sortByFst) rs
                 else rs
 
 results ∷ GetContext → Size → [(Double, Text)]

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -482,6 +482,11 @@ main = hspec $ do
       it "should return [(1, \"xxx\")]" $
         get set "xxx" `shouldBe` [(1, "xxx")]
 
+    describe "getWithMinScore 0.7 ((defaultSet `addMany` replicate 133 \"Nebraska\") `add` \"Nevada\") \"Nevoda\"" $ do
+      let set = (defaultSet `addMany` replicate 133 "Nebraska") `add` "Nevada"
+      it "should return one result" $
+        (length . getWithMinScore 0.7 set) "Nevoda" `shouldBe` 1
+
     checkMatches testset_1 "ant"   3 [("trent", 1), ("restaurant", 2), ("aunt", 1), ("smarty pants", 1)]
     checkMatches testset_1 "pant"  3 [("trent", 1), ("restaurant", 2), ("aunt", 1), ("smarty pants", 2)]
     checkMatches testset_1 "pants" 3 [("restaurant", 1), ("smarty pants", 4)]


### PR DESCRIPTION
Levenshtein algorithm will process presorted values. So for Levenshtein list will be sorted twice, but second time only 50 elements will be sorted. So I hope it's not a big issue.
#2 